### PR TITLE
フッタを一番下に固定するよう修正

### DIFF
--- a/hokudai_furima/static/css/base.css
+++ b/hokudai_furima/static/css/base.css
@@ -1,3 +1,14 @@
+html {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 main {
+  flex: 1;
   padding-top: 30px;
 }


### PR DESCRIPTION
## 仕様
フッタを一番下に固定するよう修正

## 動作確認
以下のような、高さが極端に小さい・大きいページでもフッタが他の要素と重なったり、下に余白ができたりしていないことを確認する

- ログインページ
- 検索ページ
- トップページ
- ガイドページ