### PR TITLE
Chat ui

### DIFF
--- a/hokudai_furima/static/css/style.css
+++ b/hokudai_furima/static/css/style.css
@@ -38,7 +38,7 @@
 	*display: inline;
 	*zoom: 1;
 	line-height: 1.3;
-	max-width: 60%;
+	max-width: 90%;
 	text-align: left;
 }
 

--- a/templates/chat/partials/_chat.html
+++ b/templates/chat/partials/_chat.html
@@ -41,7 +41,7 @@
 
 {% if request.user.is_authenticated %}
     <div class="row">
-        <div class="col-8 offset-2">
+        <div class="col-lg-8 offset-lg-2 col-12">
             <form method="POST" action="{% url 'chat:post_talk' %}" id="user_talk_form">{% csrf_token %}
                 <input type="hidden" name="product_id" value={{product.id}}>
                 <input type="hidden" name="talk_reciever_id" value={{talk_reciever_id}}>


### PR DESCRIPTION
To close #137 

## 仕様
- チャットのフォームの幅をスマホのとき大きくなるようにした（col-md以下のサイズをcol-12に変更）
- チャットメッセージの幅をmax-width: 60 -> 90%に変更