### PR TITLE
firefoxでボタンの中のaタグが機能しない問題を修正

### DIFF
--- a/templates/product/product_details.html
+++ b/templates/product/product_details.html
@@ -56,9 +56,7 @@
             {% if request.user == product.seller %}
               <div class="row">
                 <div class="col-md-6" style="margin:15px 15px 0px 15px; padding:0;">
-                  <button type="button" class="btn btn-lg btn-block btn-info">
-                    <a href="{% url "product:update_product" product.pk %}" style="display:block; color:white; text-decoration:none">商品情報の編集</a>
-                  </button>
+                  <a href="{% url "product:update_product" product.pk %}" class="btn btn-lg btn-block btn-info" style="display:block; color:white; text-decoration:none">商品情報の編集</a>
                 </div>
               </div>
             {% else %}
@@ -117,9 +115,7 @@
               {% if request.user != product.seller %}
                   <div class="row">
                     <div class="col-md-6" style="margin:15px 15px 0px 15px; padding:0;">
-                      <button type="button" class="btn btn-lg btn-block" style="background-color:#fe6222;">
-                        <a href="{% url 'product:product_direct_chat' product.pk request.user.pk %}" style="display:block; color:white; text-decoration:none">非公開チャット</a>
-                      </button>
+                      <a href="{% url 'product:product_direct_chat' product.pk request.user.pk %}" class="btn btn-lg btn-block" style="display:block; color:white; background-color:#fe6222; text-decoration:none">非公開チャット</a>
                     </div>
                   </div>
               {% endif %}


### PR DESCRIPTION
to fix #142 

## 仕様
- ボタンの中でaタグを使わないようにし、aタグにbootstrapのクラスをつける

## 動作確認
- 見た目が前と変わらない
- firefoxでリンクが機能する