### PR TITLE
少なすぎた最新商品を最大80個まで増やす

### DIFF
--- a/hokudai_furima/core/views.py
+++ b/hokudai_furima/core/views.py
@@ -4,7 +4,8 @@ from hokudai_furima.product.utils import get_public_product_list, fetch_latest_s
 
 # Create your views here.
 def home(request):
-    latest_products = get_public_product_list(Product.objects.all().order_by('-created_date')[:16])
+    MAX_NUM_LATEST_PRODUCT = 80
+    latest_products = get_public_product_list(Product.objects.all().order_by('-created_date')[:MAX_NUM_LATEST_PRODUCT])
     latest_sold_products = fetch_latest_sold_timeline()
     return render(request, 'home.html', {'product_list': latest_products, 'latest_sold_products': latest_sold_products})
 


### PR DESCRIPTION
トップページに表示する最新商品の数が少なすぎた（１６。ページネーションの意味がない）ので、最大80個まで増やしました