### PR TITLE
プロフィール編集画面の画像フォームのバグ修正

### DIFF
--- a/hokudai_furima/static/js/optional_single_image_form.js
+++ b/hokudai_furima/static/js/optional_single_image_form.js
@@ -1,0 +1,91 @@
+$(function(){
+    for(var i=0;i<4;i++){
+        if($('#img'+i).attr('src') != PLACEHOLDER_IMAGE){
+            $("#edde"+i).html('<button type="button" id="rem'+i+'" onclick="resetImg('+i+');return false;">削除</button>');
+        }
+    }
+})
+
+function getImageOriginalWidth(element){
+    var img = new Image();
+    img.src = element.attr('src');
+    var imageOriginaWidth = img.width;
+    return imageOriginaWidth;
+}
+
+function getImageOriginalHeight(element){
+    var img = new Image();
+    img.src = element.attr('src');
+    var imageOriginaHeight = img.height;
+    return imageOriginaHeight;
+}
+
+function addImageFitDirectionName(sender_image_id){
+    console.log("add class");
+    sender_image = $('#img'+sender_image_id)
+    let width = getImageOriginalWidth(sender_image);
+    console.log(width)
+    let height = getImageOriginalHeight(sender_image);
+    console.log(height)
+    if(width >= height){
+        sender_image.attr('class', 'width_larger')
+    }else{
+        sender_image.attr('class', 'height_larger');
+    }
+}
+
+function fileget(imgfile,targetID){
+    targetID=+targetID;
+    if(!imgfile.files.length) return;
+    var acceptimg = ['image/jpeg', 'image/png']
+
+    var loop_count = 0;
+    new Promise(function(res, rej) {
+        // ループ処理（再帰的に呼び出し）
+        function loop(i) {
+            // 非同期処理なのでPromiseを利用
+            return new Promise(function(resolve, reject) {
+
+                var fr=new FileReader();
+                fr.onload=function(e) {
+                    if(acceptimg.indexOf(imgfile.files[loop_count].type)==-1){
+                        alert("ファイル形式はjpegかpngにしてください。");
+                    }else if(e.target.result.length>1024*1024*20){
+                        alert("20MB以下の画像をアップロードできます。");
+                    }else{
+                        console.log(i);
+                        $("#img"+i).attr("src",e.target.result);
+                        $("#base64_"+i).val(e.target.result);
+                        $("#edde"+i).html('<button type="button" id="rem'+i+'" onclick="resetImg('+i+');return false;">削除</button>');
+                        resolve(i+1);
+                        $("input[name=image_"+targetID+"_exists]").val(1);
+                    }
+                }
+                console.log("loop_count:"+loop_count);
+                fr.readAsDataURL(imgfile.files[loop_count]);
+
+            })
+                .then(function(count) {
+                    // ループを抜けるかどうかの判定
+                    if (count < targetID+imgfile.files.length) {
+                        loop_count+=1;
+                        // 再帰的に実行
+                        loop(count);
+                    } else {
+                        loop_count+=1;
+                        // 抜ける（外側のPromiseのresolve判定を実行）
+                        res();
+                    }
+                });
+        }
+        // 初回実行
+        loop(targetID);
+    }).then(function() {
+        // ループ処理が終わったらここにくる
+        console.log("add class");
+        console.log("Finish");
+        addImageFitDirectionName(targetID);
+        console.log("add class");
+    })
+}
+

--- a/hokudai_furima/static/js/optional_single_image_form.js
+++ b/hokudai_furima/static/js/optional_single_image_form.js
@@ -21,12 +21,9 @@ function getImageOriginalHeight(element){
 }
 
 function addImageFitDirectionName(sender_image_id){
-    console.log("add class");
     sender_image = $('#img'+sender_image_id)
     let width = getImageOriginalWidth(sender_image);
-    console.log(width)
     let height = getImageOriginalHeight(sender_image);
-    console.log(height)
     if(width >= height){
         sender_image.attr('class', 'width_larger')
     }else{
@@ -53,7 +50,6 @@ function fileget(imgfile,targetID){
                     }else if(e.target.result.length>1024*1024*20){
                         alert("20MB以下の画像をアップロードできます。");
                     }else{
-                        console.log(i);
                         $("#img"+i).attr("src",e.target.result);
                         $("#base64_"+i).val(e.target.result);
                         $("#edde"+i).html('<button type="button" id="rem'+i+'" onclick="resetImg('+i+');return false;">削除</button>');
@@ -61,7 +57,6 @@ function fileget(imgfile,targetID){
                         $("input[name=image_"+targetID+"_exists]").val(1);
                     }
                 }
-                console.log("loop_count:"+loop_count);
                 fr.readAsDataURL(imgfile.files[loop_count]);
 
             })
@@ -82,10 +77,7 @@ function fileget(imgfile,targetID){
         loop(targetID);
     }).then(function() {
         // ループ処理が終わったらここにくる
-        console.log("add class");
-        console.log("Finish");
         addImageFitDirectionName(targetID);
-        console.log("add class");
     })
 }
 

--- a/templates/account/edit.html
+++ b/templates/account/edit.html
@@ -6,7 +6,7 @@
     let PLACEHOLDER_IMAGE = "{% static 'img/placeholder.png' %}";
 </script>
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script type="text/javascript" src="{% static 'js/image_form_utils.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/optional_single_image_form.js' %}"></script>
 {% block css %}
   <link rel="stylesheet" href="{% static 'css/lock_img_aspect.css' %}">
   <link rel="stylesheet" href="{% static 'css/hide_djangoform_message.css' %}">


### PR DESCRIPTION
## WHY
- プロフィール編集画面(/account/edit)で、以下の問題があった
  - 画像を変更せずに他の値だけ（例えばユーザ名だけ）変更してsaveボタンを押した時、「一番左に商品画像をアップロードして下さい。」とアラートが出てsaveできない

## WHAT
- プロフィール画像編集画面で画像を変更しなくてもそのままsaveできるように修正
- ユーザプロフィール変更用に新しいjsスクリプトを作りなおした