### PR TITLE
販売・購入後に応援ツイートを促す

### DIFF
--- a/hokudai_furima/rating/views.py
+++ b/hokudai_furima/rating/views.py
@@ -30,7 +30,7 @@ def post_rating(request, product_pk):
                 rating_todo.done()
                 rating_todo.update()
                 messages.success(request, 'ユーザ評価ありがとうございます。あなたの評価は相手のユーザページに反映されます。')
-                return redirect('account:others_page', user_pk=rated_user.pk)
+                return redirect('account:others_page', user_pk=rated_user.pk, is_after_rating="true")
             else:
                 messages.error(request, '評価は一度しかできません')
                 #todo_list

--- a/templates/account/others_page.html
+++ b/templates/account/others_page.html
@@ -57,4 +57,7 @@
     <p>このユーザはまだ商品を出品していません。</p>
   {% endif %}
 </div>
+{% if is_after_rating %}
+  {% include "after_rating_modal.html" %}
+{% endif %}
 {% endblock %}

--- a/templates/after_rating_modal.html
+++ b/templates/after_rating_modal.html
@@ -12,12 +12,12 @@
       <div class="modal-body">
         取引お疲れ様でした！よろしければ、ぜひ「ホクマ」の応援ツイートをお願いします。
         <div class="sns-buttons">
-          <div class="twitter-button">
+          <div class="twitter-button" style="text-align:center; margin:20px 0px 20px 0px">
             　<a href="//twitter.com/share" class="twitter-share-button" data-text="北大生限定フリマ「ホクマ」を応援しています！　#ホクマ #北大 @hufurimaさんから" data-url="https://hufurima.com/" data-lang="ja">Tweet</a>
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-dismiss="modal">閉じる</button>
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
         </div>
       </div>
     </div>

--- a/templates/after_rating_modal.html
+++ b/templates/after_rating_modal.html
@@ -1,0 +1,34 @@
+{% load static %}
+{% block content %}
+<div class="modal fade" id="after-rating-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">ホクマを応援！</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        取引お疲れ様でした！よろしければ、ぜひ「ホクマ」の応援ツイートをお願いします。
+        <div class="sns-buttons">
+          <div class="twitter-button">
+            　<a href="//twitter.com/share" class="twitter-share-button" data-text="北大生限定フリマ「ホクマ」を応援しています！　#ホクマ #北大 @hufurimaさんから" data-url="https://hufurima.com/" data-lang="ja">Tweet</a>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block post_javascript %}
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <script type="text/javascript">
+    $(window).on('load',function(){
+        $('#after-rating-modal').modal('show');
+    });
+  </script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
   </head>
   <body>
     {% include "gtm_body.html" %}
@@ -40,5 +39,8 @@
     <footer>
       {% include "footer.html" %}
     </footer>
+  {% block post_javascript %}
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## 仕様
close#156

## 動作確認
- 販売・購入の後のユーザ評価後、応援ツイートを促すmodalを表示
- ツイートボタンからツイートができる
- 普段ユーザページにいったとき発火しない