### PR TITLE
販売済みの商品を更新できないように変更

### DIFF
--- a/hokudai_furima/product/views.py
+++ b/hokudai_furima/product/views.py
@@ -83,8 +83,9 @@ def get_posted_product_images(request):
 
 @login_required
 def update_product(request, product_pk):
-    print(request.POST)
     product = get_object_or_404(Product, pk=product_pk)
+    if product.is_sold:
+        return render(request, 'product/cant_update_sold_product.html', {'product_name': product.title, 'product_pk': product.pk})
     product_seller_id = product.seller.id
     if product_seller_id != request.user.id:
         return HttpResponse('invalid request')

--- a/templates/product/cant_update_sold_product.html
+++ b/templates/product/cant_update_sold_product.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+  <div class="container">
+    <h2>販売済みの商品です</h2>
+    <p>あなたの出品した「{{ product_name }}」は販売済みのため、商品情報を変更することはできません。（販売後の情報変更によるトラブル防止のためです）</p>
+    <a href="{% url 'product:product_details' pk=product_pk %}">商品ページに戻る</a>
+  </div>
+{% endblock %}


### PR DESCRIPTION
fix#182

/product/update/:id にアクセスすると、product.is_soldがTrueなら、更新ページには行かず新しく作成した「更新できないよページ」に飛ぶように変更

これによって販売済み商品の情報を変更できないようにした
