### PR TITLE
チャットページの商品名とユーザ名表示をリンクに変更

### DIFF
--- a/templates/product/product_direct_chat.html
+++ b/templates/product/product_direct_chat.html
@@ -2,11 +2,11 @@
 {% load static %}
 {% block content %}
 <div class="container">
-    <h2 style="text-align:center">{{product}}</h2>
+    <h2 style="text-align:center"><a href="{% url 'product:product_details' product.pk %}">{{product}}</a></h2>
     {% if request.user == wanting_user %}
-        <h2 style="text-align:center">{{product.seller}}</h2>
+        <h2 style="text-align:center"><a href="{% url 'account:others_page' product.seller.pk %}">{{product.seller}}</a></h2>
     {% else %}
-        <h2 style="text-align:center">{{wanting_user}}</h2>
+        <h2 style="text-align:center"><a href="{% url 'account:others_page' wanting_user.pk %}">{{wanting_user}}</a></h2>
     {% endif %}
     {% include "chat/partials/_chat.html" %}
 </div>


### PR DESCRIPTION
Fix #187 

- チャットページの
  - 商品名を商品へのリンクに変更
  - ユーザ名をユーザへのリンクに変更
