### PR TITLE
画像がアップできなかった商品でも代わりのサムネイルを表示

### DIFF
--- a/hokudai_furima/product/views.py
+++ b/hokudai_furima/product/views.py
@@ -136,7 +136,11 @@ def product_details(request, pk):
     if request.user.pk != product.seller.pk:
         product.increment_watched_count()
     wanting_users = product.wanting_users.all()
-    ogp_image_url = product.productimage_set.first().thumbnail_url
+    ogp_image = product.productimage_set.first()
+    if ogp_image:
+        ogp_image_url = ogp_image.thumbnail_url
+    else:
+        ogp_image_url = None
     if request.user.is_authenticated:
         if request.user == product.seller:
             chatting_users = list(map(lambda x:x.product_wanting_user, Chat.objects.filter(product=product)))

--- a/templates/product/_pagenated_product_list.html
+++ b/templates/product/_pagenated_product_list.html
@@ -16,7 +16,11 @@
               </div>
             {% endif %}
             <div class="square-box">
-              <img data-src="{{ product.productimage_set.all.0.thumbnail_url }}" class="lazyload img-fluid">
+              {% if product.productimage_set.all %}
+                <img data-src="{{ product.productimage_set.all.0.thumbnail_url }}" class="lazyload img-fluid">
+              {% else %}
+                <img data-src="{% static 'img/placeholder.png' %}" class="lazyload img-fluid">
+              {% endif %}
             </div>
             <div class="caption">
               <h4>{{ product.title}}</h4>

--- a/templates/product/_product_list.html
+++ b/templates/product/_product_list.html
@@ -15,7 +15,11 @@
               </div>
             {% endif %}
             <div class="square-box">
-              <img data-src="{{ product.productimage_set.all.0.thumbnail_url }}" class="lazyload img-fluid">
+              {% if product.productimage_set.all %}
+                <img data-src="{{ product.productimage_set.all.0.thumbnail_url }}" class="lazyload img-fluid">
+              {% else %}
+                <img data-src="{% static 'img/placeholder.png' %}" class="lazyload img-fluid">
+              {% endif %}
             </div>
             <div class="caption">
               <h4>{{ product.title}}</h4>

--- a/templates/product/product_details.html
+++ b/templates/product/product_details.html
@@ -31,15 +31,25 @@
               {% endfor %}
             </ol>
             <div class="carousel-inner">
-              {% for image in product.productimage_set.all %}
-                {% if forloop.counter0 == 0 %}
-                  <div class="carousel-item active">
-                {% else %}
-                  <div class="carousel-item text-center">
-                {% endif %}
-              <img data-src="{{ image.thumbnail_url }}" class="lazyload img-fluid">
-              </div>
-              {% endfor %}
+              {% if product.productimage_set.all %}
+                {% for image in product.productimage_set.all %}
+                  {% if forloop.counter0 == 0 %}
+                    <div class="carousel-item active">
+                  {% else %}
+                    <div class="carousel-item text-center">
+                  {% endif %}
+                  {% if image %}
+                    <img data-src="{{ image.thumbnail_url }}" class="lazyload img-fluid">
+                  {% else %}
+                    <img data-src="{% static 'img/placeholder.png' %}" class="lazyload img-fluid">
+                  {% endif %}
+                </div>
+                {% endfor %}
+              {% else %}
+                <div class="carousel-item active">
+                  <img data-src="{% static 'img/placeholder.png' %}" class="lazyload img-fluid">
+                </div>
+              {% endif %}
               </div>
               <a class="carousel-control-prev" href="#carouselIndicators" data-slide="prev">
                 <span class="carousel-control-prev-icon"></span>


### PR DESCRIPTION
Fix #222 

画像のない商品でも、代わりのサムネイルを表示

- product_deitals ページ
- 各種product listページ
  - _product_list.html
  - _pagenated_product_list.thml