### PR TITLE
ホクマタイトル:商品ページの<title>の中身を商品名にへんこう

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,13 @@
 <html lang="ja">
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
     {% include "gtm_head.html" %}
-    <title>{% block title %}{% if title %}{{ title }}{% else %}ホクマ 北大生のためのフリマサイト{% endif %}{% endblock %}</title>
+    <title>
+        {% block title %}
+        {% if product %}{{ product.title }}
+        {% else %}ホクマ 北大生のためのフリマサイト
+        {% endif %}
+        {% endblock %}
+    </title>
       <meta name="description" content="北大生が開発！北大生による北大生のためのフリマサイト「ホクマ」です。直接会って渡すから、手数料０。北大生同士の運命の出会いもあるかも・・・？">
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,7 @@
     {% include "gtm_head.html" %}
     <title>
         {% block title %}
-        {% if product %}{{ product.title }}
+        {% if product %}{{ product.title }} - ホクマ
         {% else %}ホクマ 北大生のためのフリマサイト
         {% endif %}
         {% endblock %}


### PR DESCRIPTION
## WHY
Resolve #231


## WHAT
- 商品ページのtitleタグの中身を「商品名 - ホクマ」に変更した


## 参考
よしおさん