### PR TITLE
ホーム画面のクエリ最適化と不要なクエリの削除

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ six = "==1.11.0"
 urllib3 = "==1.24.1"
 Pillow = "==5.0.0"
 django-js-asset = "==1.1.0"
+django-debug-toolbar = "*"
 
 [packages]
 boto3 = "==1.7.24"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "90153adb123f52761c1ddb6472ddc503eff8414e3cff141c8e79735e0b6d7c7f"
+            "sha256": "6d503a66ecc3c1452ba3b6bac98c9134994dde95f2891f8bac1a0c8507365df4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -299,6 +299,22 @@
             ],
             "version": "==3.0.4"
         },
+        "django": {
+            "hashes": [
+                "sha256:a32c22af23634e1d11425574dce756098e015a165be02e4690179889b207c7a8",
+                "sha256:d6393918da830530a9516bbbcbf7f1214c3d733738779f06b0f649f49cc698c3"
+            ],
+            "index": "pypi",
+            "version": "==2.1.5"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:89d75b60c65db363fb24688d977e5fbf0e73386c67acf562d278402a10fc3736",
+                "sha256:c2b0134119a624f4ac9398b44f8e28a01c7686ac350a12a74793f3dd57a9eea0"
+            ],
+            "index": "pypi",
+            "version": "==1.11"
+        },
         "django-js-asset": {
             "hashes": [
                 "sha256:8ec12017f26eec524cab436c64ae73033368a372970af4cf42d9354fcb166bdd",
@@ -386,6 +402,13 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec",
+                "sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4"
+            ],
+            "version": "==0.2.4"
         },
         "urllib3": {
             "hashes": [

--- a/config/settings.py
+++ b/config/settings.py
@@ -309,3 +309,9 @@ try:
     from .local_settings import *
 except ImportError:
     pass
+
+
+if DEBUG:
+    INSTALLED_APPS.append('debug_toolbar')
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware',)
+    INTERNAL_IPS = ['127.0.0.1', '192.168.33.1']

--- a/config/urls.py
+++ b/config/urls.py
@@ -24,3 +24,9 @@ urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) # ç
 
 if settings.DEBUG:
     urlpatterns += path('admin/', admin.site.urls),
+
+    # for debug_toolbar
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+        ]

--- a/hokudai_furima/core/views.py
+++ b/hokudai_furima/core/views.py
@@ -5,7 +5,7 @@ from hokudai_furima.product.utils import get_public_product_list, fetch_latest_s
 # Create your views here.
 def home(request):
     MAX_NUM_LATEST_PRODUCT = 160
-    latest_products = get_public_product_list(Product.objects.all().order_by('-created_date')[:MAX_NUM_LATEST_PRODUCT])
+    latest_products = get_public_product_list(Product.objects.all().prefetch_related('productimage_set').order_by('-created_date')[:MAX_NUM_LATEST_PRODUCT])
     latest_sold_products = fetch_latest_sold_timeline()
     return render(request, 'home.html', {'product_list': latest_products, 'latest_sold_products': latest_sold_products})
 

--- a/hokudai_furima/core/views.py
+++ b/hokudai_furima/core/views.py
@@ -2,10 +2,9 @@ from django.shortcuts import render
 from hokudai_furima.product.models import Product
 from hokudai_furima.product.utils import get_public_product_list, fetch_latest_sold_timeline
 
+
 # Create your views here.
 def home(request):
     MAX_NUM_LATEST_PRODUCT = 160
     latest_products = get_public_product_list(Product.objects.all().prefetch_related('productimage_set').order_by('-created_date')[:MAX_NUM_LATEST_PRODUCT])
-    latest_sold_products = fetch_latest_sold_timeline()
-    return render(request, 'home.html', {'product_list': latest_products, 'latest_sold_products': latest_sold_products})
-
+    return render(request, 'home.html', {'product_list': latest_products})


### PR DESCRIPTION
## WHY
Resolve #277

- ホーム画面の商品リストのクエリを最適化したい

## WHAT
- SQL等計測ツールdjango-debug-toolbarの導入
- ホーム画面の商品リストのクエリを最適化（商品画像に対して）
  - 1 + n 回かかっていたクエリが1 + 1回に削減
- 不要なクエリ（変数latest_product_list）の削除