### PR TITLE
非ログインユーザにのみ「ホクマの特徴」などを表示するように変更

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -6,6 +6,7 @@
 {% endblock %}
 {% block content %}
   <div class="container">
+    {% if not request.user.is_authenticated %}
     <div class="row">
       <div class="col-lg-6 col-12">
         <section style="margin-bottom: 30px">
@@ -40,6 +41,7 @@
         {% include "sold_timeline.html" %}
       </section>
     </div>
+    {% endif %}
     <section id="temporary-pr">
       {% include 'temporary_PR.html' %}
     </section>


### PR DESCRIPTION
## WHY
Resolve #257 


## WHAT
- 非ログインユーザにのみ以下の表示が見れるように変更 in /
  - ホクマの特徴
  - 最近売れている商品
    - もともとよく使ってくれているユーザに対してはあまり「売れてますよ」アピールをする必要がなさそう
    - ページを全体的にスッキリさせるため
  - 購入者ガイド
    - これは迷ったが、ページの情報が少なくなることによりフッタのガイドリンクに気づくのではないかと考えた