### PR TITLE
「最近購入されている商品」がViewから渡されないバグの修正

### DIFF
--- a/hokudai_furima/core/views.py
+++ b/hokudai_furima/core/views.py
@@ -7,4 +7,5 @@ from hokudai_furima.product.utils import get_public_product_list, fetch_latest_s
 def home(request):
     MAX_NUM_LATEST_PRODUCT = 160
     latest_products = get_public_product_list(Product.objects.all().prefetch_related('productimage_set').order_by('-created_date')[:MAX_NUM_LATEST_PRODUCT])
-    return render(request, 'home.html', {'product_list': latest_products})
+    latest_sold_products = fetch_latest_sold_timeline()
+    return render(request, 'home.html', {'product_list': latest_products, 'latest_sold_products': latest_sold_products})


### PR DESCRIPTION
## WHY
Resolve #293 


## WHAT
- latest_sold_productをViewから渡すように修正