### PR TITLE
速度改善のため、キャッシュの期間を長くする

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -234,8 +234,8 @@ AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
 AWS_S3_CUSTOM_DOMAIN = os.getenv('HOKUDAI_FURIMA_CLOUDFRONT_HOST')
 AWS_S3_OBJECT_PARAMETERS = {
-    'Expires': 'Thu, 31 Dec 2020 20:00:00 GMT',
-    'CacheControl': 'max-age=86400',
+    'Expires': 'Thu, 31 Dec 2021 20:00:00 GMT',
+    'CacheControl': 'max-age=2592000',
 }
 AWS_STATIC_LOCATION = 'static'
 STATIC_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, AWS_STATIC_LOCATION)


### PR DESCRIPTION
## WHY
Resolve #296 


## WHAT
- settings.pyのキャッシュのCache-Controlを一日から一ヶ月に変更
- expireも1年増やして2021年にした


## 備考
先に本番環境で実践済み。以下のことを行った

- このプルリク同様の変更
- S3のファイルを一旦削除（staticディレクトリ）
- Cloudfrontのキャッシュをinvalidation
- デプロイ＆collect static