### PR TITLE
チャットの順番を常に若い順に表示する

### DIFF
--- a/hokudai_furima/matching_offer/tests.py
+++ b/hokudai_furima/matching_offer/tests.py
@@ -1,3 +1,60 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+import datetime
+from hokudai_furima.account.models import User
+from hokudai_furima.matching_offer.models import MatchingOffer, MatchingOfferTalk
 
-# Create your tests here.
+
+def create_user(username, email, password):
+    user = User.objects.create_user(username=username, email=email, password=password, is_active=True)
+    return user
+
+
+def confirm_site_rules(user):
+    user.is_rules_confirmed = True
+    user.save()
+    return user
+
+
+def activate_user(user):
+    user.is_active = True
+    user.save()
+    return user
+
+
+def create_matching_offer(user, title, description):
+    product = MatchingOffer.objects.create(host=user, title=title, description=description)
+    return product
+
+
+def add_talk_to_matching_offer(talker, matching_offer, text, days):
+    time = timezone.now() + datetime.timedelta(days=days)
+    MatchingOfferTalk.objects.create(talker=talker,
+                                     matching_offer=matching_offer,
+                                     text=text,
+                                     created_date=time)
+
+
+class ProductDirectChatViewTests(TestCase):
+    def test_two_past_questions(self):
+        """
+        The questions index page may display multiple questions.
+        """
+        host = create_user('test1', 'test1@eis.hokudai.ac.jp', 'hokuma1')
+        guest = create_user('test2', 'test2@eis.hokudai.ac.jp', 'hokuma2')
+        host = activate_user(host)
+        guest = activate_user(guest)
+        host = confirm_site_rules(host)
+        guest = confirm_site_rules(guest)
+        matching_offer = create_matching_offer(host, 'テストオファー', 'テストオファーです')
+        add_talk_to_matching_offer(guest, matching_offer, '行きたいです', days=-2)
+        add_talk_to_matching_offer(host, matching_offer, 'ぜひ来てください！', days=-1)
+        client = Client()
+        client.force_login(host, backend='django.contrib.auth.backends.ModelBackend')
+        response = client.get(reverse('matching_offer:matching_offer_details',
+                                      kwargs={'pk': matching_offer.pk}))
+        self.assertQuerysetEqual(
+            response.context['talks'],
+            ['<MatchingOfferTalk: MatchingOfferTalk object (1)>', '<MatchingOfferTalk: MatchingOfferTalk object (2)>']
+        )

--- a/hokudai_furima/matching_offer/views.py
+++ b/hokudai_furima/matching_offer/views.py
@@ -22,7 +22,7 @@ def make_matching_offer_image_forms(request):
 
 def matching_offer_details(request, pk):
     matching_offer = get_object_or_404(MatchingOffer, pk=pk)
-    talks = MatchingOfferTalk.objects.filter(matching_offer=matching_offer)
+    talks = MatchingOfferTalk.objects.filter(matching_offer=matching_offer).order_by('created_date')
     talk_form = MatchingOfferTalkForm()
     return render(request, 'matching_offer/matching_offer_details.html', {'matching_offer': matching_offer, 'talks': talks, 'form': talk_form})
 

--- a/hokudai_furima/product/tests.py
+++ b/hokudai_furima/product/tests.py
@@ -1,3 +1,68 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+import datetime
+from hokudai_furima.account.models import User
+from hokudai_furima.product.models import Product
+from hokudai_furima.chat.models import Chat, Talk
 
-# Create your tests here.
+
+def create_user(username, email, password):
+    user = User.objects.create_user(username=username, email=email, password=password, is_active=True)
+    return user
+
+
+def comfirm_site_rules(user):
+    user.is_rules_confirmed = True
+    user.save()
+    return user
+
+
+def activate_user(user):
+    user.is_active = True
+    user.save()
+    return user
+
+
+def create_product(user, title, description, price):
+    product = Product.objects.create(seller=user, title=title, description=description, price=price)
+    return product
+
+
+def create_chat(product, product_wanting_user, product_seller):
+    chat = Chat.objects.create(product=product,
+                               product_wanting_user=product_wanting_user,
+                               product_seller=product_seller,
+                               created_date=timezone.now())
+    return chat
+
+
+def add_talk_to_chat(talker, chat, sentence, days):
+    time = timezone.now() + datetime.timedelta(days=days)
+    talk = Talk.objects.create(talker=talker, chat=chat, sentence=sentence, created_date=time)
+    chat.talk_set.add(talk)
+
+
+class ProductDirectChatViewTests(TestCase):
+    def test_two_past_questions(self):
+        """
+        The questions index page may display multiple questions.
+        """
+        seller = create_user('test1', 'test1@eis.hokudai.ac.jp', 'hokuma1')
+        wanting_user = create_user('test2', 'test2@eis.hokudai.ac.jp', 'hokuma2')
+        seller = activate_user(seller)
+        wanting_user = activate_user(wanting_user)
+        seller = comfirm_site_rules(seller)
+        wanting_user = comfirm_site_rules(wanting_user)
+        product = create_product(seller, 'テスト商品', 'テスト商品です', 100)
+        chat = create_chat(product, wanting_user, seller)
+        add_talk_to_chat(talker=wanting_user, chat=chat, sentence='購入希望送らせていただきました', days=-2)
+        add_talk_to_chat(talker=seller, chat=chat, sentence='購入希望ありがとうございます！', days=-1)
+        client = Client()
+        client.force_login(seller, backend='django.contrib.auth.backends.ModelBackend')
+        response = client.get(reverse('product:product_direct_chat',
+                                           kwargs={'product_pk': product.pk, 'wanting_user_pk': wanting_user.pk}))
+        self.assertQuerysetEqual(
+            response.context['talks'],
+            ['<Talk: Talk object (1)>', '<Talk: Talk object (2)>']
+        )

--- a/hokudai_furima/product/views.py
+++ b/hokudai_furima/product/views.py
@@ -193,7 +193,7 @@ def product_direct_chat(request, product_pk, wanting_user_pk):
     if (request.user == wanting_user and request.user != product.seller) or (request.user == product.seller and request.user != wanting_user):
         chat = Chat.objects.filter(product=product, product_wanting_user=wanting_user, product_seller=product.seller)
         if chat.exists():
-            talks = chat[0].talk_set.all()
+            talks = chat[0].talk_set.all().order_by('created_date')
         else:
             # チャットルームがなけれは、新たにチャットルームを作る（ただし、保存はしない。トークの投稿があって初めて保存）
             # 売り手以外の人は、自由にチャットルームを作れる


### PR DESCRIPTION
## WHY
Solve #230

- 「仲間募集」と「（商品の）非公開チャット」のチャットの順番がうまく並ばないときがあった

## WHAT
- 「仲間募集」と「（商品の）非公開チャット」のチャットの順番を時系列順に若い順に表示（下に行くほど新しい）
- テストも書いた


## test result
```
$ python manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..
----------------------------------------------------------------------
Ran 2 tests in 0.528s

OK
Destroying test database for alias 'default'...
```