### PR TITLE
ユーザ評価後のシェアモーダルが出るようにする

### DIFF
--- a/hokudai_furima/account/views.py
+++ b/hokudai_furima/account/views.py
@@ -87,7 +87,14 @@ def others_page(request, user_pk):
     normal_rating_count = UserRating.objects.filter(rated_user=others_user, rating='normal').count()
     bad_rating_count = UserRating.objects.filter(rated_user=others_user, rating='bad').count()
     others_user_product_list = get_public_product_list(Product.objects.filter(seller=others_user))
-    return render(request, 'account/others_page.html', {'others_user': others_user, 'good_rating_count': good_rating_count, 'normal_rating_count':normal_rating_count, 'bad_rating_count':bad_rating_count, 'others_user_product_list': others_user_product_list})
+    contexts = {'others_user': others_user, 'good_rating_count': good_rating_count,
+                'normal_rating_count': normal_rating_count, 'bad_rating_count': bad_rating_count,
+                'others_user_product_list': others_user_product_list}
+    is_after_rating_key = 'is_after_rating'
+    is_after_rating_parameter = request.GET.get(is_after_rating_key)
+    if is_after_rating_parameter:
+        contexts[is_after_rating_key] = is_after_rating_parameter
+    return render(request, 'account/others_page.html', contexts)
 
 
 @login_required

--- a/hokudai_furima/rating/views.py
+++ b/hokudai_furima/rating/views.py
@@ -33,7 +33,9 @@ def post_rating(request, product_pk):
                 rating_todo.done()
                 rating_todo.update()
                 messages.success(request, 'ユーザ評価ありがとうございます。あなたの評価は相手のユーザページに反映されます。')
-                return redirect('account:others_page', user_pk=rated_user.pk)
+                response = redirect('account:others_page', user_pk=rated_user.pk)
+                response['location'] += '?is_after_rating=true'
+                return response
             else:
                 messages.error(request, '評価は一度しかできません')
 

--- a/templates/account/others_page.html
+++ b/templates/account/others_page.html
@@ -61,3 +61,13 @@
   {% include "after_rating_modal.html" %}
 {% endif %}
 {% endblock %}
+{% if is_after_rating %}
+  {% block post_javascript %}
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <script type="text/javascript">
+        $(window).on('load',function(){
+            $('#after-rating-modal').modal('show');
+        });
+    </script>
+  {% endblock %}
+{% endif %}

--- a/templates/after_rating_modal.html
+++ b/templates/after_rating_modal.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% block content %}
 <div class="modal fade" id="after-rating-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -23,12 +22,3 @@
     </div>
   </div>
 </div>
-{% endblock %}
-{% block post_javascript %}
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <script type="text/javascript">
-    $(window).on('load',function(){
-        $('#after-rating-modal').modal('show');
-    });
-  </script>
-{% endblock %}


### PR DESCRIPTION
## WHY
Resolve #307 


## WHAT
- ユーザ評価後、リダイレクトページにユーザ評価後を示すパラメータを渡せるようにした
- モーダルが開けるようにjsの読み込みタイミングを修正

## 参考
https://narito.ninja/blog/detail/74/
https://stackoverflow.com/questions/9633387/django-using-blocks-in-included-templates