### PR TITLE
スマホトップページ表示用アイコンリンクの修正

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -25,8 +25,8 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static 'css/category_list_nav.css' %}">
     <link rel="icon" href="{% static 'img/favicon.ico' %}">
-    <link rel="apple-touch-icon" href="{% static 'img//apple-touch-icon.png" sizes="180x180' %}" >
-    <link rel="icon" type="image/png" href="{% static 'img//android-touch-icon.png" sizes="192x192' %}" >
+    <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}">
+    <link rel="icon" type="image/png" href="{% static 'img/android-touch-icon.png' %}">
   </head>
   <body>
     <header>


### PR DESCRIPTION
## WHY
- #310 が失敗していたので修正

## WHAT
- スマホトップページ表示用アイコンリンクの修正
  - link間違いの修正
 - sizesの修正