### PR TITLE
商品・オファーの表示順を統一

### DIFF
--- a/hokudai_furima/account/views.py
+++ b/hokudai_furima/account/views.py
@@ -72,12 +72,12 @@ def login(request, backends='django.contrib.auth.backends.ModelBackend'):
 @site_rules_confirm_required
 @login_required
 def mypage(request):
-    wanting_product_list = get_public_product_list(Product.objects.filter(wanting_users=request.user))
-    selling_product_list = Product.objects.filter(seller=request.user)
+    wanting_product_list = get_public_product_list(Product.objects.filter(wanting_users=request.user)).order_by('-id')
+    selling_product_list = Product.objects.filter(seller=request.user).order_by('-id')
     notification_list = fetch_notification_list(request)
     sorted_undone_todo_list = get_undone_todo_list(request.user)
     sorted_done_todo_list = get_done_todo_list(request.user)
-    my_matching_offer_list = MatchingOffer.objects.filter(host=request.user)
+    my_matching_offer_list = MatchingOffer.objects.filter(host=request.user).order_by('-id')
     return render(request, 'account/mypage.html', {'wanting_product_list': wanting_product_list, 'selling_product_list': selling_product_list, 'my_matching_offer_list': my_matching_offer_list, 'notification_list': notification_list, 'done_todo_list': sorted_done_todo_list, 'undone_todo_list': sorted_undone_todo_list})
 
 

--- a/hokudai_furima/product/views.py
+++ b/hokudai_furima/product/views.py
@@ -279,7 +279,7 @@ def category_details(request, pk):
         category_parent_chain.append(temp_parent_category)
         temp_parent_category = temp_parent_category.parent
     category_parent_chain.reverse()
-    category_products = get_public_product_list(category.category_products.all())
+    category_products = get_public_product_list(category.product_category_products.all().order_by('-id'))
 
     child_categories = category.children.all()
     return render(request, 'product/category_details.html', {'category': category, 'category_parent_chain': category_parent_chain, 'child_categories': child_categories, 'category_products': category_products})


### PR DESCRIPTION
## WHY
Resolve #313 

## WHAT
- バグフィックスも同時に行いました
  - categoryの商品一覧へのアクセスミス
- 商品・オファーの表示順を統一（降順＝新しい順）
  - マイページ
  - category_detailsページ