### PR TITLE
マイページ用のテストコード追加

### DIFF
--- a/hokudai_furima/account/tests.py
+++ b/hokudai_furima/account/tests.py
@@ -1,3 +1,42 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.urls import reverse
+from hokudai_furima.account.models import User
 
-# Create your tests here.
+
+def create_user(username, email, password):
+    user = User.objects.create_user(username=username, email=email, password=password, is_active=True)
+    return user
+
+
+def comfirm_site_rules(user):
+    user.is_rules_confirmed = True
+    user.save()
+    return user
+
+
+def activate_user(user):
+    user.is_active = True
+    user.save()
+    return user
+
+
+class MypageViewTests(TestCase):
+    def test_not_login_mypage_status_code_302(self):
+        client = Client()
+        response = client.get(reverse('account:mypage'))
+        self.assertEqual(
+            response.status_code,
+            302
+        )
+
+    def test_loggedin_mypage_status_code_200(self):
+        user = create_user('test1', 'test1@eis.hokudai.ac.jp', 'hokuma1')
+        user = activate_user(user)
+        user = comfirm_site_rules(user)
+        client = Client()
+        client.force_login(user, backend='django.contrib.auth.backends.ModelBackend')
+        response = client.get(reverse('account:mypage'))
+        self.assertEqual(
+            response.status_code,
+            200
+        )


### PR DESCRIPTION
## WHY
- ランタイムエラーが出た時のためのテストがほしい
- なんらかのロジックがエラーになったとき（特に文法ミスなどの些細なミス）


## WHAT
- account/mypage にアクセスした時のテストを書いた
  - ログインしているとき: ステータスコードが200かチェック（エラーなら500など）
  - ログインしていないとき: ステータスコードが302かチェック（エラーなら500など）