### PR TITLE
科目区分詳細ページで非公開の商品が表示されている問題の修正

### DIFF
--- a/hokudai_furima/lecture/views.py
+++ b/hokudai_furima/lecture/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404
 from .models import LectureCategory
+from hokudai_furima.product.utils import get_public_product_list
 
 
 def count_all_node_children_related_product(_lecture_category_list):
@@ -43,7 +44,7 @@ def lecture_category_details(request, pk):
         lecture_category_parent_chain.append(temp_parent_lecture_category)
         temp_parent_lecture_category = temp_parent_lecture_category.parent
     lecture_category_parent_chain.reverse()
-    lecture_category_products = lecture_category.lecture_category_products.all().order_by('-id')
+    lecture_category_products = get_public_product_list(lecture_category.lecture_category_products.all().order_by('-id'))
 
     child_lecture_categories = lecture_category.children.all().order_by('id')
     return render(request, 'lecture/lecture_category_details.html',


### PR DESCRIPTION
## WHY
- 科目区分詳細ページ /lecture/details/{pk} で非公開の商品が表示されている


## WHAT
- get_public_product_listで囲んで修正