### PR TITLE
Add help text to singup form to clear valid email before validation

### DIFF
--- a/hokudai_furima/account/forms.py
+++ b/hokudai_furima/account/forms.py
@@ -5,7 +5,8 @@ from ..account.models import User
 from django.contrib.auth import forms as django_forms, update_session_auth_hash
 from . import emails
 import re
- 
+
+
 class SignupForm(django_forms.UserCreationForm):
     class Meta:
         model = User
@@ -17,6 +18,11 @@ class SignupForm(django_forms.UserCreationForm):
         m = re.search('@eis.hokudai.ac.jp$',email)
         if m is None:
             self._errors["email"]=["登録に使えるのは@eis.hokudai.ac.jpを持つメールアドレスのみです。"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['email'].help_text= "登録に使えるのは@eis.hokudai.ac.jpを持つメールアドレスのみです。"
+
 
 class LoginForm(django_forms.AuthenticationForm):
 


### PR DESCRIPTION
## WHY
Resolve #321 


## WHAT
- サインアップフォームのemail部分に「登録に使えるのは@eis.hokudai.ac.jpを持つメールアドレスのみです。」とhelptextをつけた


## 参考
https://narito.ninja/blog/detail/98/

https://hombre-nuevo.com/python/python0037/