### PR TITLE
不要なcsrf_tokenパラメータの削除

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,7 +44,7 @@
             </a>
           </div>
           <div class="search-bar">
-            <form method="GET" action="{% url 'search:search_product' %}" class="search-form ml-auto">{% csrf_token %}
+            <form method="GET" action="{% url 'search:search_product' %}" class="search-form ml-auto">
               <input type='hidden' name="price_range" value='0_1000000' />
               <input type='hidden' name="is_sold" value='all' />
               <input type='hidden' name="sort_method" value='sort_new' />

--- a/templates/search/product/search_product.html
+++ b/templates/search/product/search_product.html
@@ -10,7 +10,7 @@
 {% block content %}
     <div class="container">
         <div>
-            <form method="GET" class="post-form">{% csrf_token %}
+            <form method="GET" class="post-form">
                 {% bootstrap_form keyword_form layout='virtical' %}
                 <div id="main_suggest_area">
                 </div>


### PR DESCRIPTION
## WHY
Resolve #328 

- URLにcsrf_tokenパラメータが露出しており、問題は特にないはずだが気持ち悪い。
- 不要なので削除しておく。

## WHAT
- /search/product の不要なcsrf_tokenパラメータの削除
- homeなどのヘッダの検索バーの不要なcsrf_tokenパラメータの削除


## 参考
- https://docs.djangoproject.com/en/2.2/ref/csrf/

> The first defense against CSRF attacks is to ensure that GET requests (and other ‘safe’ methods, as defined by RFC 7231#section-4.2.1) are side effect free. Requests via ‘unsafe’ methods, such as POST, PUT, and DELETE, can then be protected by following the steps below.

- https://developer.cybozu.io/hc/ja/articles/360001197206-CSRFトークンを取得する

> HTTPメソッドが GET のAPIでは CSRFトークンは不要です。

ただし、問題のある情報の取得・変更を行うような場合はcsrf tokenを使った防御が必要なはず。（今回は純粋な検索なので問題はない）